### PR TITLE
Update the extension to work with the updated daisuki page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,8 @@
 {
 	"manifest_version": 2,
-
 	"name": "Daisuki.net HTML5 player",
 	"description": "Allows playing streams on Daisuki.net without flash",
-	"version": "1.4",
+	"version": "1.5",
 	
 	"icons": {
 		"16": "icon16.png",
@@ -12,7 +11,7 @@
 	},
 	
 	"content_scripts": [{
-		"matches": [ "http://www.daisuki.net/*" ],
+		"matches": [ "http://motto.daisuki.net/*" ],
 		"run_at": "document_end",
 		"js": ["page.js"]
 	}],
@@ -29,8 +28,9 @@
 		"storage",
 		"webRequest",
 		"webRequestBlocking",
-		"http://www.daisuki.net/*",
-		"https://www.daisuki.net/*"
+		"http://motto.daisuki.net/*",
+		"https://motto.daisuki.net/*",
+		"http://releases.flowplayer.org/*",
+		"https://releases.flowplayer.org/*"
 	]
-
 }

--- a/page.js
+++ b/page.js
@@ -19,11 +19,11 @@ s.href = chrome.extension.getURL('subtitles.css');
 // JS
 
 s = document.createElement('script');
-s.src = chrome.extension.getURL('flowplayer.min.js');
+s.src = "//releases.flowplayer.org/7.0.1/flowplayer.min.js";
 (document.head || document.documentElement).appendChild(s);
 
 s = document.createElement('script');
-s.src = chrome.extension.getURL('flowplayer.hlsjs.min.js');
+s.src = "//releases.flowplayer.org/hlsjs/1.1.1/flowplayer.hlsjs.min.js";
 (document.head || document.documentElement).appendChild(s);
 
 s = document.createElement('script');


### PR DESCRIPTION
Since daisuki now loads the swf from an iframe, the extension has been modified to update the page on the iframe being loaded.

I'm relatively new to javascript and chrome extensions so I also included the required js includes (from daisuke) because I don't know how to get them usable on the root page from the iframe or externally.